### PR TITLE
fix(deps): pin nadi-kit to v0.1.2 (was unpinned main)

### DIFF
--- a/.github/workflows/research-heartbeat.yml
+++ b/.github/workflows/research-heartbeat.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FEDERATION_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          python -m pip install --upgrade "git+https://${GH_TOKEN}@github.com/kimeisele/steward-federation.git#egg=nadi-kit"
+          python -m pip install --upgrade "git+https://${GH_TOKEN}@github.com/kimeisele/steward-federation.git@v0.1.2#egg=nadi-kit"
 
       - name: Run NADI heartbeat cycle
         env:


### PR DESCRIPTION
nadi-kit was installed unpinned from steward-federation main in the heartbeat workflow; a change to main could drift the executed Nadi code. Pin to the new annotated tag v0.1.2 (commit 03008a5a, nadi_kit.py blob 47d8e3bb...). Content-identical today; deterministic from now on.